### PR TITLE
fix: sp() string aliases + Badge subtle dark-theme contrast

### DIFF
--- a/packages/components/src/layout/__tests__/layout.test.tsx
+++ b/packages/components/src/layout/__tests__/layout.test.tsx
@@ -440,6 +440,49 @@ describe('SimpleGrid', () => {
 })
 
 // ---------------------------------------------------------------------------
+// sp() string aliases
+// ---------------------------------------------------------------------------
+describe('sp string aliases', () => {
+  it('resolves xs to space-1', () => {
+    const { container } = wrap(<Box p="xs">content</Box>)
+    const el = getEl(container)
+    expect(el.style.paddingLeft).toBe('var(--forge-space-1)')
+  })
+
+  it('resolves sm to space-2', () => {
+    const { container } = wrap(<Box p="sm">content</Box>)
+    const el = getEl(container)
+    expect(el.style.paddingLeft).toBe('var(--forge-space-2)')
+  })
+
+  it('resolves md to space-4', () => {
+    const { container } = wrap(
+      <Stack gap="md">
+        <div>a</div>
+      </Stack>,
+    )
+    const el = getEl(container)
+    expect(el.style.gap).toBe('var(--forge-space-4)')
+  })
+
+  it('resolves lg to space-6', () => {
+    const { container } = wrap(<Box px="lg">content</Box>)
+    const el = getEl(container)
+    expect(el.style.paddingLeft).toBe('var(--forge-space-6)')
+  })
+
+  it('resolves xl to space-8', () => {
+    const { container } = wrap(
+      <Flex gap="xl">
+        <div>a</div>
+      </Flex>,
+    )
+    const el = getEl(container)
+    expect(el.style.gap).toBe('var(--forge-space-8)')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Wrap
 // ---------------------------------------------------------------------------
 describe('Wrap', () => {

--- a/packages/components/src/layout/layoutUtils.ts
+++ b/packages/components/src/layout/layoutUtils.ts
@@ -7,10 +7,20 @@ export type SpaceValue = number | string
 
 const SPACE_SCALE = new Set([0, 0.5, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32, 40, 48, 64])
 
+const SPACE_ALIASES: Record<string, number> = {
+  xs: 1,
+  sm: 2,
+  md: 4,
+  lg: 6,
+  xl: 8,
+}
+
 /** Converts a space scale value to a CSS var or passes through raw CSS strings. */
 export function sp(val: SpaceValue | undefined): string | undefined {
   if (val === undefined) return undefined
   if (val === 'px') return 'var(--forge-space-px)'
+  if (typeof val === 'string' && val in SPACE_ALIASES)
+    return `var(--forge-space-${SPACE_ALIASES[val]})`
   if (typeof val === 'number' && SPACE_SCALE.has(val)) return `var(--forge-space-${val})`
   return String(val)
 }

--- a/packages/components/src/primitives/Badge.tsx
+++ b/packages/components/src/primitives/Badge.tsx
@@ -63,9 +63,9 @@ export function Badge({
       : variant === 'outline'
         ? { backgroundColor: 'transparent', color: base, border: `1px solid ${border}` }
         : {
-            backgroundColor: `color-mix(in srgb, ${base} 15%, transparent)`,
+            backgroundColor: `color-mix(in srgb, ${base} 20%, transparent)`,
             color: base,
-            border: `1px solid color-mix(in srgb, ${base} 25%, transparent)`,
+            border: `1px solid color-mix(in srgb, ${base} 40%, transparent)`,
           }
 
   return (


### PR DESCRIPTION
## Summary

Root-cause fixes for the ForgeUI Usage Audit (Amerzel/Forge#235).

### Changes

#### 1. sp() string alias support
Add `xs→1, sm→2, md→4, lg→6, xl→8` mapping to `sp()` in `layoutUtils.ts`. This resolves ~101 Forge app files that pass `gap="sm"`, `p="md"`, etc. — previously these produced invalid CSS like `gap: sm` which browsers ignored (zero spacing).

#### 2. Badge subtle variant contrast
Increase `color-mix` percentages for the subtle variant: background 15%→20%, border 25%→40%. Fixes near-invisible badges on dark theme backgrounds across 96 occurrences in the Forge app.

### Testing

- 5 new tests for string alias resolution (xs/sm/md/lg/xl)
- All 451 component tests passing
- All 28 token tests passing